### PR TITLE
Fall back to key if source language is empty

### DIFF
--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -89,6 +89,11 @@ abstract class Translation
      * @param $language
      */
     public function translateLanguage($language){
+        //No need to translate e.g. English to English
+        if ($language === $this->sourceLanguage) {
+            return;
+        }
+
         $translations = $this->getSourceLanguageTranslationsWith($language);
 
         foreach ($translations as $type => $groups) {

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -70,7 +70,6 @@ abstract class Translation
     }
 
     /**
-     *
      * Translate text using Google Translate
      *
      * @param $language
@@ -79,7 +78,7 @@ abstract class Translation
      * @throws \ErrorException
      */
     public function getGoogleTranslate($language,$token){
-        $tr = new GoogleTranslate($language);
+        $tr = new GoogleTranslate($language, $this->sourceLanguage);
         return $tr->translate($token);
     }
 

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -98,7 +98,9 @@ abstract class Translation
         foreach ($translations as $type => $groups) {
             foreach ($groups as $group => $translations) {
                 foreach ($translations as $key => $value) {
-                    $sourceLanguageValue = $value[$this->sourceLanguage];
+                    //Value will be empty if it's found in the app source code but not in the source language files
+                    //We fall back to $key in that case
+                    $sourceLanguageValue = in_array($value[$this->sourceLanguage], ["", null]) ? $key : $value[$this->sourceLanguage];
                     $targetLanguageValue = $value[$language];
 
                     if (in_array($targetLanguageValue, ["", null])) {


### PR DESCRIPTION
I decided to add all relevant features and bugfixes to my own fork, as they don't really make sense to combine into a single PR back to upstream and I don't know when upstream will merge the multiple PRs.

The upstream PR for this bug is https://github.com/timoye/laravel-translation/pull/3

----
- It'll not try to translate strings where the source language is the same as the target language
- It specifies the source language so Google Translate doesn't have to guess
- If the source language files (e.g. `en.json`) don't have a value assigned to a key (or if it's missing from there completely), it'll fall back to translating the key instead of the value.

