### PR TITLE
Make placeholder workaround less likely to be mangled by Google Translate

### DIFF
--- a/resources/lang/en/translation.php
+++ b/resources/lang/en/translation.php
@@ -17,6 +17,7 @@ return [
     'language_key_added' => 'New language key added successfully 👏',
     'no_missing_keys' => 'There are no missing translation keys in the app 🎉',
     'keys_synced' => 'Missing keys synchronised successfully 🎊',
+    'auto_translated_language' => 'Finished translating :language.',
     'auto_translated' => 'Automated Translation completed successfully 🎊',
     'search' => 'Search all translations',
     'translations' => 'Translation',

--- a/src/Console/Commands/AutoTranslateKeysCommand.php
+++ b/src/Console/Commands/AutoTranslateKeysCommand.php
@@ -37,7 +37,7 @@ class AutoTranslateKeysCommand extends BaseCommand
         } catch (\Exception $e) {
             return $this->error($e->getMessage());
         }
-        
-        
+
+
     }
 }

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -66,6 +66,8 @@ abstract class Translation
         foreach ($languages as $language => $name) {
             $this->saveMissingTranslations($language);
             $this->translateLanguage($language);
+            //Inform the user of what language we just finished translating
+            fwrite(STDOUT, __('translation::translation.auto_translated_language', ['language' => $language]) . PHP_EOL);
         }
     }
 

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -120,7 +120,9 @@ abstract class Translation
         if (count($translatedMatches[0]) !== count($placeholders)) {
             // Print a warning to stderr
             fwrite(STDERR, sprintf(
-                "Warning: Placeholder count mismatch in translated text.\nOriginal text: %s\nTranslated text: %s\nExpected placeholders: %s\nActual placeholders: %s\n",
+                "Warning: Placeholder count mismatch in translated text when translating %s to %s.\nOriginal text: %s\nTranslated text: %s\nExpected placeholders: %s\nActual placeholders: %s\n",
+                $this->sourceLanguage,
+                $language,
                 $token,
                 $translatedText,
                 json_encode($placeholders),


### PR DESCRIPTION
Other improvements:

- Make pluralization variant handling  more robust by sending them to Google Translate separately
- Some logging improvements.