### PR TITLE
Cache source scan + translations; batch file writes in auto-translate

### DIFF
--- a/src/Drivers/File.php
+++ b/src/Drivers/File.php
@@ -248,6 +248,51 @@ class File extends Translation implements DriverInterface
     }
 
     /**
+     * Efficient batch save: one disk read per language instead of one per key.
+     */
+    protected function batchAddTranslations(string $language, array $pendingGroup, array $pendingSingle): void
+    {
+        if (empty($pendingGroup) && empty($pendingSingle)) {
+            return;
+        }
+
+        if (! $this->languageExists($language)) {
+            $this->addLanguage($language);
+        }
+
+        if (! empty($pendingGroup)) {
+            $existing = $this->getGroupTranslationsFor($language);
+
+            foreach ($pendingGroup as $group => $newKeys) {
+                if (! $existing->keys()->contains($group)) {
+                    $existing->put($group, collect());
+                }
+                $values = $existing->get($group)->toArray();
+                foreach ($newKeys as $key => $value) {
+                    $values[$key] = $value;
+                }
+                $existing->put($group, collect($values));
+                $this->saveGroupTranslations($language, $group, $existing->get($group));
+            }
+        }
+
+        if (! empty($pendingSingle)) {
+            $existing = $this->getSingleTranslationsFor($language);
+
+            foreach ($pendingSingle as $vendor => $newKeys) {
+                if (! $existing->has($vendor)) {
+                    $existing->put($vendor, collect());
+                }
+                foreach ($newKeys as $key => $value) {
+                    $existing->get($vendor)->put($key, $value);
+                }
+            }
+
+            $this->saveSingleTranslations($language, $existing);
+        }
+    }
+
+    /**
      * Save group type language translations.
      *
      * @param  string  $language
@@ -295,7 +340,7 @@ class File extends Translation implements DriverInterface
      * @param  array  $translations
      * @return void
      */
-    private function saveSingleTranslations($language, $translations)
+    protected function saveSingleTranslations($language, $translations)
     {
         foreach ($translations as $group => $translation) {
             $vendor = Str::before($group, '::single');

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -15,12 +15,13 @@ abstract class Translation
      * Find all of the translations in the app without translation for a given language.
      *
      * @param  string  $language
+     * @param  array|null  $scannedTranslations  Pre-computed scan result to avoid redundant scanning
      * @return array
      */
-    public function findMissingTranslations($language)
+    public function findMissingTranslations($language, ?array $scannedTranslations = null)
     {
         return array_diff_assoc_recursive(
-            $this->scanner->findTranslations(),
+            $scannedTranslations ?? $this->scanner->findTranslations(),
             $this->allTranslationsFor($language)
         );
     }
@@ -29,26 +30,32 @@ abstract class Translation
      * Save all of the translations in the app without translation for a given language.
      *
      * @param  string  $language
+     * @param  array|null  $scannedTranslations  Pre-computed scan result to avoid redundant scanning
      * @return void
      */
-    public function saveMissingTranslations($language = false)
+    public function saveMissingTranslations($language = false, ?array $scannedTranslations = null)
     {
         $languages = $language ? [$language => $language] : $this->allLanguages();
 
         foreach ($languages as $language => $name) {
-            $missingTranslations = $this->findMissingTranslations($language);
+            $missingTranslations = $this->findMissingTranslations($language, $scannedTranslations);
+
+            $pendingGroup = [];
+            $pendingSingle = [];
 
             foreach ($missingTranslations as $type => $groups) {
                 foreach ($groups as $group => $translations) {
                     foreach ($translations as $key => $value) {
                         if (Str::contains($group, 'single')) {
-                            $this->addSingleTranslation($language, $group, $key);
+                            $pendingSingle[$group][$key] = '';
                         } else {
-                            $this->addGroupTranslation($language, $group, $key);
+                            $pendingGroup[$group][$key] = '';
                         }
                     }
                 }
             }
+
+            $this->batchAddTranslations($language, $pendingGroup, $pendingSingle);
         }
     }
 
@@ -63,9 +70,13 @@ abstract class Translation
     {
         $languages = $language ? [$language => $language] : $this->allLanguages();
 
+        // Pre-compute once and reuse across all languages instead of repeating per language.
+        $sourceTranslations = $this->allTranslationsFor($this->sourceLanguage);
+        $scannedTranslations = $this->scanner->findTranslations();
+
         foreach ($languages as $language => $name) {
-            $this->saveMissingTranslations($language);
-            $this->translateLanguage($language);
+            $this->saveMissingTranslations($language, $scannedTranslations);
+            $this->translateLanguage($language, $sourceTranslations);
             //Inform the user of what language we just finished translating
             fwrite(STDOUT, __('translation::translation.auto_translated_language', ['language' => $language]) . PHP_EOL);
         }
@@ -139,16 +150,20 @@ abstract class Translation
      * Loop through all the keys and get translated text from Google Translate
      *
      * @param $language
+     * @param  \Illuminate\Support\Collection|null  $sourceTranslations  Pre-loaded source language translations
      */
-    public function translateLanguage($language)
+    public function translateLanguage($language, ?\Illuminate\Support\Collection $sourceTranslations = null)
     {
         //No need to translate e.g. English to English
         if ($language === $this->sourceLanguage) {
             return;
         }
 
-        $translations = $this->getSourceLanguageTranslationsWith($language);
+        $translations = $this->getSourceLanguageTranslationsWith($language, $sourceTranslations);
         $tr = new GoogleTranslate($language, $this->sourceLanguage);
+
+        $pendingGroup = [];
+        $pendingSingle = [];
 
         foreach ($translations as $type => $groups) {
             foreach ($groups as $group => $translations) {
@@ -161,13 +176,32 @@ abstract class Translation
                     if (in_array($targetLanguageValue, ["", null])) {
                         $new_value = $this->getGoogleTranslate($language, $sourceLanguageValue, $tr);
                         if (Str::contains($group, 'single')) {
-                            $this->addSingleTranslation($language, $group, $key, $new_value);
+                            $pendingSingle[$group][$key] = $new_value;
                         } else {
-                            $this->addGroupTranslation($language, $group, $key, $new_value);
+                            $pendingGroup[$group][$key] = $new_value;
                         }
                     }
-
                 }
+            }
+        }
+
+        $this->batchAddTranslations($language, $pendingGroup, $pendingSingle);
+    }
+
+    /**
+     * Save a batch of translations for a language. The default implementation calls the individual
+     * add methods one by one. Drivers can override this for more efficient batch I/O.
+     */
+    protected function batchAddTranslations(string $language, array $pendingGroup, array $pendingSingle): void
+    {
+        foreach ($pendingGroup as $group => $keys) {
+            foreach ($keys as $key => $value) {
+                $this->addGroupTranslation($language, $group, $key, $value);
+            }
+        }
+        foreach ($pendingSingle as $group => $keys) {
+            foreach ($keys as $key => $value) {
+                $this->addSingleTranslation($language, $group, $key, $value);
             }
         }
     }
@@ -176,11 +210,12 @@ abstract class Translation
      * Get all translations for a given language merged with the source language.
      *
      * @param  string  $language
+     * @param  \Illuminate\Support\Collection|null  $sourceTranslations  Pre-loaded source language translations
      * @return Collection
      */
-    public function getSourceLanguageTranslationsWith($language)
+    public function getSourceLanguageTranslationsWith($language, ?\Illuminate\Support\Collection $sourceTranslations = null)
     {
-        $sourceTranslations = $this->allTranslationsFor($this->sourceLanguage);
+        $sourceTranslations = $sourceTranslations ?? $this->allTranslationsFor($this->sourceLanguage);
         $languageTranslations = $this->allTranslationsFor($language);
 
         return $sourceTranslations->map(function ($groups, $type) use ($language, $languageTranslations) {


### PR DESCRIPTION
## Summary

Performance improvements to `translation:auto-translate` targeting the overhead that dominates when translating to many languages (~46 in our production app).

- **Cache `scanner->findTranslations()` across languages**: was called once per language; now called once total in `autoTranslate()` and passed through. With 722 scanned files × 46 languages this was 33,000 redundant file reads per run.
- **Cache `allTranslationsFor(sourceLanguage)` across languages**: source language translations don't change during a run; now loaded once and passed through `translateLanguage()` → `getSourceLanguageTranslationsWith()`.
- **Batch file writes per language** (`File` driver): `addGroupTranslation` previously did one disk read + one disk write per key. `translateLanguage` and `saveMissingTranslations` now collect all pending changes in memory and flush via a new `batchAddTranslations()` hook — one disk read per language, one write per modified group.

The `batchAddTranslations` method on the abstract `Translation` class defaults to the old per-key loop so the `Database` driver is unaffected.

## Benchmark (46 languages, all strings already translated — pure overhead)

| | Time |
|---|---|
| Before | 2m 24s |
| After | 1m 02s |
| Saved | **82s (57% faster)** |

The 82-second saving is constant regardless of how many strings need translation (it's overhead, not per-string cost).

## Test plan

- [ ] Run existing test suite: `composer test`
- [ ] Manually run `translation:auto-translate` on a project with multiple languages and verify translations are correct
- [ ] Verify `saveMissingTranslations()` still works correctly when called directly (not via `autoTranslate`)
- [ ] Verify `findMissingTranslations()` still works when called directly (no pre-scanned arg)