### PR TITLE
Fix scanner running N times per command in sync-missing and list-missing

### DIFF
--- a/src/Console/Commands/ListMissingTranslationKeys.php
+++ b/src/Console/Commands/ListMissingTranslationKeys.php
@@ -27,9 +27,10 @@ class ListMissingTranslationKeys extends BaseCommand
     {
         $missingTranslations = [];
         $rows = [];
+        $scannedTranslations = $this->translation->scanForTranslations();
 
         foreach ($this->translation->allLanguages() as $language => $name) {
-            $missingTranslations[$language] = $this->translation->findMissingTranslations($language);
+            $missingTranslations[$language] = $this->translation->findMissingTranslations($language, $scannedTranslations);
         }
 
         // check whether or not there are any missing translations

--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -38,6 +38,8 @@ abstract class Translation
     public function saveMissingTranslations($language = false, ?array $scannedTranslations = null, ?\Illuminate\Support\Collection $targetTranslations = null)
     {
         $languages = $language ? [$language => $language] : $this->allLanguages();
+        // Pre-compute once so the scanner doesn't run once per language when called for all languages.
+        $scannedTranslations ??= $this->scanner->findTranslations();
 
         foreach ($languages as $language => $name) {
             $missingTranslations = $this->findMissingTranslations($language, $scannedTranslations, $targetTranslations);

--- a/tests/FileDriverTest.php
+++ b/tests/FileDriverTest.php
@@ -496,6 +496,38 @@ class FileDriverTest extends TestCase
     }
 
     /** @test */
+    public function save_missing_translations_for_all_languages_scans_once(): void
+    {
+        $scanner = $this->createMock(\JoeDixon\Translation\Scanner::class);
+        $scanner->expects($this->once())
+            ->method('findTranslations')
+            ->willReturn(['single' => [], 'group' => []]);
+
+        app()->instance(\JoeDixon\Translation\Scanner::class, $scanner);
+        app()->forgetInstance(Translation::class);
+        $translation = app()->make(Translation::class);
+
+        // Two languages (en + es) in fixtures — scanner must still only run once.
+        $translation->saveMissingTranslations(false);
+    }
+
+    /** @test */
+    public function list_missing_translation_keys_command_scans_once(): void
+    {
+        $scanner = $this->createMock(\JoeDixon\Translation\Scanner::class);
+        $scanner->expects($this->once())
+            ->method('findTranslations')
+            ->willReturn(['single' => [], 'group' => []]);
+
+        app()->instance(\JoeDixon\Translation\Scanner::class, $scanner);
+        app()->forgetInstance(Translation::class);
+
+        // Two languages (en + es) in fixtures — scanner must still only run once.
+        $this->artisan('translation:list-missing-translation-keys')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
     public function batch_translate_falls_back_to_individual_calls_when_batch_split_fails()
     {
         $individualCallCount = 0;


### PR DESCRIPTION
## Problem

`translation:sync-missing-translation-keys` and `translation:list-missing-translation-keys` both called `scanner->findTranslations()` — which reads and regex-scans every file in the configured scan paths — once per language rather than once per command run.

- **`saveMissingTranslations(false)`** (used by `sync-missing`): called `findMissingTranslations` per language with no pre-computed scan, triggering a full codebase scan each iteration.
- **`ListMissingTranslationKeys::handle()`**: looped over languages calling `findMissingTranslations($language)` with no pre-computed scan.

## Fix

- **`saveMissingTranslations`**: add `$scannedTranslations ??= $this->scanner->findTranslations()` before the language loop, so the scan is computed once regardless of how the method is called (externally with a pre-computed result, or internally for all languages).
- **`ListMissingTranslationKeys`**: pre-compute `scanForTranslations()` before the loop and pass it to each `findMissingTranslations` call.

## Tests

Adds two regression tests that assert `findTranslations()` is called exactly once regardless of language count:
- `save_missing_translations_for_all_languages_scans_once`
- `list_missing_translation_keys_command_scans_once`

---
*Companion to #24 — that PR fixed the double file-read per language in `auto-translate`; this one fixes the equivalent scanner issue in the other two commands.*