### PR TITLE
Replace Google-introduced pipes with a danda instead of escaping them

### DIFF
--- a/src/Drivers/Translation.php
+++ b/src/Drivers/Translation.php
@@ -148,6 +148,50 @@ abstract class Translation
     }
 
     /**
+     * Fix pipe characters that Google Translate introduced into a translated piece.
+     *
+     * Laravel has no escape sequence for pipes in translation strings:
+     * MessageSelector::choose() does a plain explode('|', $line) and never
+     * unescapes \|, so neither a bare nor an "escaped" pipe may ever be stored.
+     * Pieces are split on | before being sent to Google, so any pipe in the
+     * response was introduced by Google. The only known cause is Odia (or),
+     * where Google renders the sentence terminator danda (।, U+0964) as an
+     * ASCII pipe. The danda attaches directly to the preceding word, so a
+     * space before the pipe is dropped along with it.
+     *
+     * Some scripts have terminators that merely resemble the danda (Tibetan
+     * shad །, Ol Chiki ᱾), so for any target language other than Odia a
+     * warning is emitted — the danda may be the wrong glyph there.
+     */
+    protected function replaceGoogleIntroducedPipes(string $piece, string $language, string $originalToken): string
+    {
+        if (! str_contains($piece, '|')) {
+            return $piece;
+        }
+
+        if ($language !== 'or') {
+            $this->warnUnexpectedPipeFromGoogle($language, $originalToken, $piece);
+        }
+
+        return preg_replace('/ ?\|/', '।', $piece);
+    }
+
+    /**
+     * Warn that Google Translate introduced a pipe for a language not known to do so.
+     */
+    protected function warnUnexpectedPipeFromGoogle(string $language, string $originalToken, string $translatedPiece): void
+    {
+        fwrite(STDERR, sprintf(
+            "Warning: Google Translate output contained a pipe character when translating %s to %s; it was replaced with a danda (।). Only Odia (or) is known to mis-render its sentence terminator as a pipe — verify the danda is the correct glyph for %s.\nOriginal text: %s\nTranslated text: %s\n",
+            $this->sourceLanguage,
+            $language,
+            $language,
+            $originalToken,
+            $translatedPiece
+        ));
+    }
+
+    /**
      * Translate text using Google Translate (single string, public API for backwards compat).
      *
      * @param $language
@@ -166,9 +210,7 @@ abstract class Translation
         $translated = [];
         foreach (explode('|', $modifiedToken) as $translatableText) {
             $piece = $tr->translate($translatableText);
-            // Escape any pipe in the translated output so Laravel doesn't mistake
-            // it for a pluralization separator (convention: \| means a literal pipe).
-            $translated[] = str_replace('|', '\\|', $piece);
+            $translated[] = $this->replaceGoogleIntroducedPipes($piece, $language, $token);
         }
         $translatedText = implode('|', $translated);
 
@@ -220,7 +262,7 @@ abstract class Translation
                 $translatedVariants = [];
                 foreach ($item['variants'] as $variant) {
                     $piece = $tr->translate($variant);
-                    $translatedVariants[] = str_replace('|', '\\|', $piece);
+                    $translatedVariants[] = $this->replaceGoogleIntroducedPipes($piece, $language, $item['token']);
                 }
                 $item['translated'] = $translatedVariants;
             }
@@ -233,7 +275,11 @@ abstract class Translation
         $resultsByItem = [];
         foreach ($splitParts as $flatIdx => $translatedPart) {
             [$itemIndex, $variantIndex] = $indexMap[$flatIdx];
-            $resultsByItem[$itemIndex][$variantIndex] = str_replace('|', '\\|', trim($translatedPart));
+            $resultsByItem[$itemIndex][$variantIndex] = $this->replaceGoogleIntroducedPipes(
+                trim($translatedPart),
+                $language,
+                $chunk[$itemIndex]['token']
+            );
         }
 
         foreach ($chunk as $itemIndex => &$item) {
@@ -291,7 +337,7 @@ abstract class Translation
             $translated = [];
             foreach (explode('|', $item['modifiedToken']) as $variant) {
                 $piece = $tr->translate($variant);
-                $translated[] = str_replace('|', '\\|', $piece);
+                $translated[] = $this->replaceGoogleIntroducedPipes($piece, $language, $item['token']);
             }
             $joined = implode('|', $translated);
             $results[$compositeKey] = $this->restorePlaceholders(

--- a/tests/FileDriverTest.php
+++ b/tests/FileDriverTest.php
@@ -381,31 +381,102 @@ class FileDriverTest extends TestCase
     }
 
     #[Test]
-    public function pipe_characters_in_google_translate_output_are_escaped()
+    public function pipe_characters_in_google_translate_output_are_replaced_with_a_danda()
     {
         $tr = $this->createMock(GoogleTranslate::class);
         $tr->method('translate')->willReturnCallback(function ($text) {
-            // Simulate a language (e.g. Odia) that ends sentences with |
+            // Simulate Odia, where Google renders the sentence terminator danda as " |"
             return $text.' |';
         });
 
         $result = $this->translation->getGoogleTranslate('or', 'Hello', $tr);
 
-        $this->assertSame('Hello \|', $result);
+        // The pipe becomes a danda attached to the preceding word — never \|,
+        // which Laravel would render literally (it has no pipe escaping).
+        $this->assertSame('Hello।', $result);
     }
 
     #[Test]
-    public function pipe_characters_in_google_translate_output_are_escaped_in_plural_strings()
+    public function pipe_characters_are_replaced_with_a_danda_for_any_target_language()
+    {
+        $driver = $this->translationWithWarningSpy();
+
+        $tr = $this->createMock(GoogleTranslate::class);
+        $tr->method('translate')->willReturnCallback(function ($text) {
+            return $text.' |';
+        });
+
+        $result = $driver->getGoogleTranslate('fr', 'Hello', $tr);
+
+        $this->assertSame('Hello।', $result);
+    }
+
+    #[Test]
+    public function a_warning_is_emitted_when_google_introduces_a_pipe_for_a_language_other_than_odia()
+    {
+        $driver = $this->translationWithWarningSpy();
+
+        $tr = $this->createMock(GoogleTranslate::class);
+        $tr->method('translate')->willReturnCallback(function ($text) {
+            return $text.' |';
+        });
+
+        $driver->getGoogleTranslate('fr', 'Hello', $tr);
+
+        $this->assertCount(1, $driver->pipeWarnings);
+        $this->assertSame('fr', $driver->pipeWarnings[0]['language']);
+        $this->assertSame('Hello', $driver->pipeWarnings[0]['originalToken']);
+    }
+
+    #[Test]
+    public function no_warning_is_emitted_when_google_introduces_a_pipe_for_odia()
+    {
+        $driver = $this->translationWithWarningSpy();
+
+        $tr = $this->createMock(GoogleTranslate::class);
+        $tr->method('translate')->willReturnCallback(function ($text) {
+            return $text.' |';
+        });
+
+        $driver->getGoogleTranslate('or', 'Hello', $tr);
+
+        $this->assertSame([], $driver->pipeWarnings);
+    }
+
+    #[Test]
+    public function pipe_characters_in_plural_strings_become_dandas_while_variants_still_join_with_a_pipe()
     {
         $tr = $this->createMock(GoogleTranslate::class);
         $tr->method('translate')->willReturnCallback(function ($text) {
             return $text.' |';
         });
 
-        // Source string has a pluralization separator; each variant gets its translated | escaped
+        // Each variant's Google-introduced | becomes a danda; the variants
+        // themselves are still joined with a genuine pluralization pipe.
         $result = $this->translation->getGoogleTranslate('or', 'One item|Many items', $tr);
 
-        $this->assertSame('One item \||Many items \|', $result);
+        $this->assertSame('One item।|Many items।', $result);
+        $this->assertStringNotContainsString('\\|', $result);
+    }
+
+    /**
+     * A File driver whose pipe warning is captured instead of written to STDERR.
+     */
+    private function translationWithWarningSpy()
+    {
+        return new class(
+            app('files'),
+            app()['path.lang'],
+            'en',
+            app(\JoeDixon\Translation\Scanner::class)
+        ) extends \JoeDixon\Translation\Drivers\File {
+            public $pipeWarnings = [];
+
+            protected function warnUnexpectedPipeFromGoogle(string $language, string $originalToken, string $translatedPiece): void
+            {
+                $this->pipeWarnings[] = compact('language', 'originalToken', 'translatedPiece');
+            }
+        };
     }
 
     #[Test]
@@ -478,7 +549,7 @@ class FileDriverTest extends TestCase
     }
 
     #[Test]
-    public function batch_translate_escapes_pipe_characters_in_batch_mode()
+    public function batch_translate_replaces_pipe_characters_with_a_danda_in_batch_mode()
     {
         $tr = $this->createMock(GoogleTranslate::class);
         $tr->method('translate')->willReturnCallback(function ($text) {
@@ -490,10 +561,10 @@ class FileDriverTest extends TestCase
             'group\0test\0hello' => 'Hello',
         ];
 
-        $results = $this->translation->batchTranslate('es', $tokens, $tr);
+        $results = $this->translation->batchTranslate('or', $tokens, $tr);
 
-        // The injected | must be escaped so Laravel doesn't treat it as a pluralization separator
-        $this->assertStringContainsString('\\|', $results['group\0test\0hello']);
+        $this->assertSame('Hello।', $results['group\0test\0hello']);
+        $this->assertStringNotContainsString('\\|', $results['group\0test\0hello']);
     }
 
     #[Test]


### PR DESCRIPTION
## The bug

`src/Drivers/Translation.php` escaped pipes in Google Translate output as `\|` in four places (introduced in 3b5b15e), on the assumption that Laravel treats `\|` as an escaped literal pipe. Laravel has no such escaping mechanism: `Illuminate\Translation\MessageSelector::choose()` does a plain `explode('|', $line)` and never unescapes `\|` (verified in the vendor source).

Observed consequences in production (Odia locale, `or`):

- Plain `__()` strings displayed a literal `\|` to users.
- Pluralized strings were worse: a stored value like `foo \||bar \|` explodes into three segments with an **empty middle one** — exactly the segment `trans_choice()` picks for plural counts — so every pluralized Odia string rendered as an empty string.

## Root cause

Google Translate renders the Odia sentence terminator (danda, ।, U+0964) as an ASCII pipe `|`. It does not do this for the other danda-script languages (hi, pa, bn, ne all come back with a proper ।); an audit of 45 production locales found Google-introduced pipes in Odia only.

Key invariant: the translate flow splits the English source on `|` **before** sending pieces to Google, so a piece sent to Google never contains a pipe. Any pipe in the response was therefore introduced by Google, and the only known reason is a mis-rendered danda.

## The fix

The four `str_replace('|', '\\|', ...)` sites are replaced with one shared helper, `replaceGoogleIntroducedPipes()`, which for every target language:

1. Replaces each pipe in a translated piece with the danda ।, dropping a single space before it (the danda attaches directly to the preceding word: `ଅଟେ |` → `ଅଟେ।`). This is unconditional — the piece sent to Google was pipe-free, so a pipe in the output can only be a mis-rendered sentence terminator.
2. For any target language other than `or`, additionally warns on STDERR naming the language and the affected string, so an unexpected Google quirk in another language gets investigated instead of going unnoticed. (Some Google-supported languages have terminators that merely resemble the danda — Tibetan shad ।, Ol Chiki ᱾ — so the replacement could be the wrong glyph there.)
3. Never writes `\|` — Laravel will never unescape it.

Genuine plural-variant joining (variants joined with `|` after translating each separately) and the fake-URL placeholder protection are untouched.

## Tests

- A fake-translated piece `Hello |` becomes `Hello।` for `or` and for other target languages (`fr`).
- The warning fires for target `fr` but not for `or` (captured via a spy subclass to keep test output clean).
- Plural variants still join with a real `|`: `One item|Many items` → `One item।|Many items।`.
- Batch mode produces the danda too, and no result contains `\|`.
- Full suite: 62 tests, 105 assertions, all passing (baseline notices unchanged — one per `GoogleTranslate` mock, a pre-existing pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
